### PR TITLE
release/20 01 2026

### DIFF
--- a/docs/journey/ios/changelogs.md
+++ b/docs/journey/ios/changelogs.md
@@ -4,6 +4,7 @@ title: Journey iOS - Changelogs - Navitia SDK Docs
 
 # Journey iOS Changelogs
 
+* [v6.4.2](releases/6.4.2/index.md) (_20 Jan 2026_)
 * [v6.4.1](releases/6.4.1/index.md) (_15 Jan 2026_)
 * [v6.4.0](releases/6.4.0/index.md) (_03 Dec 2025_)
 * [v6.3.1](releases/6.3.1/index.md) (_17 Nov 2025_)

--- a/docs/journey/ios/index.md
+++ b/docs/journey/ios/index.md
@@ -13,7 +13,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Journey podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'JourneySDK', '6.4.0' # Journey Pod definition
+  pod 'JourneySDK', '6.4.2' # Journey Pod definition
 end
 
 # Required for XCFramework

--- a/docs/journey/ios/releases/6.4.2/index.md
+++ b/docs/journey/ios/releases/6.4.2/index.md
@@ -1,0 +1,13 @@
+---
+title: Journey iOS 6.4.2 - Changelog - Navitia SDK Docs
+---
+
+# Journey iOS 6.4.2 Changelog
+
+<h2>🗓 20 Jan 2026</h2>
+
+#### Fixes 
+- Fix journey search not updating departure or arrival when my position is once selected
+
+#### Compiler
+-  Swift  `6.2.3`

--- a/docs/traffic/ios/index.md
+++ b/docs/traffic/ios/index.md
@@ -13,7 +13,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Traffic podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'TrafficSDK', '4.4.0' # Traffic Pod definition
+  pod 'TrafficSDK', '4.4.1' # Traffic Pod definition
 end
 
 # Required for XCFramework


### PR DESCRIPTION
- update doc for release 1
- update expert api and models
- clean file
- update after fixes
- remove new feature
- Update for iOS changes since release of 24 february
- add schedule android 2.9.5
- Update config
- PR changes
- Update iOS changelogs
- add android changelogs
- Update iOS pod version
- Apply some PR changes
- fix path of changelogs file
- iOS Changelogs
- Update pods versions
- Move task in the right sections
- Update Android docs
- Fix schedule changelog
- Update schedule doc
- Update changelogs.md
- Update changelogs.md
- update configuration and add missing parameters
- fix headers
- Fix Traffic options title
- edit step-by-step guidance and add result_tabs config for journey
- update icon resources for journey
- Add speed feature documentation
- minor update
- pr correction
- Update ios versions
- Add missing android releases
- Update versions in modules pages
- Update docs/around_me/android/changelogs.md
- Update index.md
- Update changelogs.md
- Add latest releases for iOS and Android
- Adjust doc
- Update config json sample
- Adjust doc
- Fix doc
- Fix doc
- Fix version
- Add journey hotfixes
- Update doc for Hotfix Schedule 4.2.2 and Traffic 4.3.1
- Add swift version to the changelogs
- Update documentation for iOS release
- add android updates
- pr corrections
- pr corrections 2
- Apply suggestions from code review
- docs: Add schedule mode configuration to GettingStarted page
- docs: Add Journey Android 5.22.1 changelog
- Update index.md
- Update index.md
- Update getting_started.md
- hotfix (Traffic ios 4.4.1 and Journey ios 6.4.1) : add changelogs for journey ios
- hotfix (Traffic ios 4.4.1 and Journey ios 6.4.1) : Change swift compiler version in journey's changelog
- chore: Changelog Traffic 4.4.1
- doc: add Journey 6.4.2 release
